### PR TITLE
fix: ensure paths point to nix store where needed in snapcraft

### DIFF
--- a/apps/snapcraft/snapcraft-data-dirs.patch
+++ b/apps/snapcraft/snapcraft-data-dirs.patch
@@ -1,45 +1,26 @@
 diff --git a/snapcraft_legacy/internal/common.py b/snapcraft_legacy/internal/common.py
-index 6017b405..d47d76cc 100644
+index 6017b405..aacd99a5 100644
 --- a/snapcraft_legacy/internal/common.py
 +++ b/snapcraft_legacy/internal/common.py
-@@ -35,13 +35,14 @@ from snaphelpers import SnapConfigOptions, SnapCtlError
+@@ -34,14 +34,17 @@ from snaphelpers import SnapConfigOptions, SnapCtlError
+ 
  from snapcraft_legacy.internal import errors
  
++# Get the path to the Nix store entry for Snapcraft at runtime
++drv = os.path.realpath(__file__).split("/")[3]
++
  SNAPCRAFT_FILES = ["parts", "stage", "prime"]
 -_DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
-+_SNAPCRAFT_LOCAL_DIR = os.path.join(Path.home(), ".local", "share", "snapcraft")
-+_DEFAULT_PLUGINDIR = os.path.join(_SNAPCRAFT_LOCAL_DIR, "plugins")
++_DEFAULT_PLUGINDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "plugins")
  _plugindir = _DEFAULT_PLUGINDIR
 -_DEFAULT_SCHEMADIR = os.path.join(sys.prefix, "share", "snapcraft", "schema")
-+_DEFAULT_SCHEMADIR = os.path.join(_SNAPCRAFT_LOCAL_DIR, "schema")
++_DEFAULT_SCHEMADIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "schema")
  _schemadir = _DEFAULT_SCHEMADIR
 -_DEFAULT_EXTENSIONSDIR = os.path.join(sys.prefix, "share", "snapcraft", "extensions")
-+_DEFAULT_EXTENSIONSDIR = os.path.join(_SNAPCRAFT_LOCAL_DIR, "extensions")
++_DEFAULT_EXTENSIONSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "extensions")
  _extensionsdir = _DEFAULT_EXTENSIONSDIR
 -_DEFAULT_KEYRINGSDIR = os.path.join(sys.prefix, "share", "snapcraft", "keyrings")
-+_DEFAULT_KEYRINGSDIR = os.path.join(_SNAPCRAFT_LOCAL_DIR, "keyrings")
++_DEFAULT_KEYRINGSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "keyrings")
  _keyringsdir = _DEFAULT_KEYRINGSDIR
  
  _DOCKERENV_FILE = "/.dockerenv"
-diff --git a/snapcraft_legacy/internal/dirs.py b/snapcraft_legacy/internal/dirs.py
-index de3cb4d7..c5c16f06 100644
---- a/snapcraft_legacy/internal/dirs.py
-+++ b/snapcraft_legacy/internal/dirs.py
-@@ -14,7 +14,7 @@
- # You should have received a copy of the GNU General Public License
- # along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
--import os.path
-+import os
- import site
- import sys
- 
-@@ -120,4 +120,7 @@ def setup_dirs() -> None:
-             common.get_keyringsdir(),
-         ]:
-             if not os.path.exists(d):
--                raise snapcraft_legacy.internal.errors.SnapcraftDataDirectoryMissingError()
-+                try:
-+                    os.makedirs(d, exist_ok=True)
-+                except:
-+                    raise snapcraft_legacy.internal.errors.SnapcraftDataDirectoryMissingError()


### PR DESCRIPTION
I noticed that `remote-build` was failing, and on further inspection my previous patching was incorrect. This should likely fix a whole bunch of bugs I've not even come across yet!