### PR TITLE
Version bumps and maintenance

### DIFF
--- a/.github/workflows/lock-updater.yaml
+++ b/.github/workflows/lock-updater.yaml
@@ -3,7 +3,7 @@ name: Flake lock updater
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   lock-updater:
@@ -25,3 +25,4 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v20
         with:
           pr-title: "chore: update flake lock file"
+          commit-msg: "chore: update flake lock file"

--- a/apps/charmcraft/default.nix
+++ b/apps/charmcraft/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "charmcraft";
-  version = "2.5.3";
+  version = "2.5.4";
 in
 pkgs.python3Packages.buildPythonApplication {
   inherit pname version;
@@ -13,7 +13,7 @@ pkgs.python3Packages.buildPythonApplication {
     owner = "canonical";
     repo = pname;
     rev = version;
-    hash = "sha256-7k7d54jq3/X/ywaiiaLWrgXQlrnb8o19j6PRrsAn9b4=";
+    hash = "sha256-u4Bn2skW2uGz34Yu30qTlDlFUIqB9izhzmZOZr67IcQ=";
   };
 
   patches = [

--- a/apps/rockcraft/default.nix
+++ b/apps/rockcraft/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "rockcraft";
-  version = "1.0.1";
+  version = "1.1.1";
 in
 pkgs.python3Packages.buildPythonApplication {
   inherit pname version;
@@ -13,7 +13,7 @@ pkgs.python3Packages.buildPythonApplication {
     owner = "canonical";
     repo = pname;
     rev = "refs/tags/${version}";
-    sha256 = "sha256-CMgpLXYiaBoD2aoZbajBIea5iAnrw4/zjKkeR4+WuCg=";
+    sha256 = "sha256-mAPkFgaqDEo/Elt9tfY7f9zwkw580ZCrnCpV736zYo8=";
   };
 
   propagatedBuildInputs = with pkgs.python3Packages; [

--- a/apps/snapcraft/default.nix
+++ b/apps/snapcraft/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "snapcraft";
-  version = "7.5.3";
+  version = "8.0.1";
 in
 pkgs.python3Packages.buildPythonApplication {
   inherit pname version;
@@ -12,8 +12,8 @@ pkgs.python3Packages.buildPythonApplication {
   src = pkgs.fetchFromGitHub {
     owner = "snapcore";
     repo = pname;
-    rev = "9ad7a93ea880b560d3c8a364617c67a3b0b6d157";
-    sha256 = "sha256-P665jh3I+C+w/elTJnx3tPROJXzeLgVXAnW1WfdQ9jw=";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-V7Wmp43M2/cmI8/60ydgX/wOFfZIksA0HAWwGLBVPFA=";
   };
 
   patches = [
@@ -59,6 +59,7 @@ pkgs.python3Packages.buildPythonApplication {
     mypy-extensions
     progressbar
     pyelftools
+    pygit2
     pylxd
     raven
     requests-toolbelt

--- a/deps/craft-application.nix
+++ b/deps/craft-application.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "craft-application";
-  version = "1.0.0";
+  version = "1.2.1";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -14,20 +14,15 @@ pkgs.python3Packages.buildPythonPackage rec {
     owner = "canonical";
     repo = pname;
     rev = version;
-    sha256 = "sha256-y6nvfSnUlxoy6Qjbxkub14cHCcp4iz6uJ489VQYVSxI=";
+    sha256 = "sha256-CXZEWVoE66dlQJp4G8tinufjyaDJaH1Muxz/qd/81oA=";
   };
-
-  patches = [
-    # ./pyproject_version.patch
-  ];
 
   postPatch = ''
     substituteInPlace craft_application/__init__.py \
       --replace "dev" "${version}"
     
     substituteInPlace pyproject.toml \
-      --replace "setuptools==67.7.2" "setuptools" \
-      # --replace "CRAFTS_FLAKE_VERSION" "${version}"
+      --replace "setuptools==67.7.2" "setuptools"
   '';
 
   propagatedBuildInputs = with pkgs.python3Packages; [

--- a/deps/craft-cli.nix
+++ b/deps/craft-cli.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "craft-cli";
-  version = "2.4.0";
+  version = "2.5.0";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -14,7 +14,7 @@ pkgs.python3Packages.buildPythonPackage rec {
     owner = "canonical";
     repo = pname;
     rev = version;
-    sha256 = "sha256-VvLoSd49C0FCNX55Mz4j4/Oz4LCchjf+W8ykzSnS7jE=";
+    sha256 = "sha256-BcL3iYlA4pkyKZNRRmMSZLP3fgDcUQbW72k8yI6Y/VA=";
   };
 
   postPatch = ''

--- a/deps/craft-grammar.nix
+++ b/deps/craft-grammar.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "craft-grammar";
-  version = "697e4ddc1f51de0ca02b349977439e37cff5bdfb";
+  version = "1.1.2";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -13,7 +13,7 @@ pkgs.python3Packages.buildPythonPackage rec {
     owner = "canonical";
     repo = pname;
     rev = version;
-    sha256 = "sha256-rfsrbcCABuEVqG24GK4bzZBAm2u2obTbLjZpEB8Xnhc=";
+    sha256 = "sha256-23KLIO2yHXGe/zb3B8LirJsh+LY9z0c5ZGtF392Kszo=";
   };
 
   propagatedBuildInputs = with pkgs.python3Packages; [

--- a/deps/craft-parts.nix
+++ b/deps/craft-parts.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "craft-parts";
-  version = "1.25.1";
+  version = "1.26.1";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -13,7 +13,7 @@ pkgs.python3Packages.buildPythonPackage rec {
     owner = "canonical";
     repo = pname;
     rev = "${version}";
-    sha256 = "sha256-UR5SsTHBfCBusc/pSv5S+nitEDsdNLZKrSyBX5Ra7OE=";
+    sha256 = "sha256-Q0GMiglo16mvJUBDhy4cnWjFiHCsW61QsZkhejCjvsE=";
   };
 
   propagatedBuildInputs = with pkgs.python3Packages;[

--- a/deps/craft-providers/default.nix
+++ b/deps/craft-providers/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   pname = "craft-providers";
-  version = "1.19.2";
+  version = "1.20.1";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -14,7 +14,7 @@ pkgs.python3Packages.buildPythonPackage rec {
     owner = "canonical";
     repo = pname;
     rev = version;
-    sha256 = "sha256-TwB6oz6EsVzF8KuVSwjjmbAE0ptmaoWF/s7xNHlEx1Q=";
+    sha256 = "sha256-EHcsgh0EO6L+HAd1M66VOp5Ha72fVyGnVECkAHYLULw=";
   };
 
   patches = [
@@ -31,7 +31,6 @@ pkgs.python3Packages.buildPythonPackage rec {
     # This is already patched in nixpkgs.
     substituteInPlace pyproject.toml \
       --replace "setuptools==67.7.2" "setuptools" \
-      --replace "pydantic<2.0" "pydantic" \
       --replace "urllib3<2" "urllib3"
   '';
 

--- a/deps/craft-providers/default.nix
+++ b/deps/craft-providers/default.nix
@@ -27,8 +27,12 @@ pkgs.python3Packages.buildPythonPackage rec {
     substituteInPlace craft_providers/__init__.py \
       --replace "dev" "${version}"
     
+    # The urllib3 incompat: https://github.com/msabramo/requests-unixsocket/pull/69
+    # This is already patched in nixpkgs.
     substituteInPlace pyproject.toml \
-      --replace "setuptools==67.7.2" "setuptools"
+      --replace "setuptools==67.7.2" "setuptools" \
+      --replace "pydantic<2.0" "pydantic" \
+      --replace "urllib3<2" "urllib3"
   '';
 
   propagatedBuildInputs = with pkgs.python3Packages; [

--- a/deps/craft-providers/inject-snaps.patch
+++ b/deps/craft-providers/inject-snaps.patch
@@ -1,8 +1,8 @@
 diff --git a/craft_providers/base.py b/craft_providers/base.py
-index c7b3abc..2c62d0c 100644
+index 3c914a2..d9c2cf9 100644
 --- a/craft_providers/base.py
 +++ b/craft_providers/base.py
-@@ -655,37 +655,21 @@ class Base(ABC):
+@@ -655,37 +655,22 @@ class Base(ABC):
                      ),
                  )
  
@@ -38,17 +38,18 @@ index c7b3abc..2c62d0c 100644
 -                        details=error.details,
 -                    ) from error
 +            try:
++                channel = "latest/edge" if snap.name == "rockcraft" else "latest/stable"
 +                snap_installer.install_from_store(
 +                    executor=executor,
 +                    snap_name=snap.name,
-+                    channel=snap.channel or "latest/stable",
++                    channel=channel,
 +                    classic=snap.classic,
 +                )
 +            except SnapInstallationError as error:
 +                raise BaseConfigurationError(
 +                    brief=(
 +                        f"failed to install snap {snap.name!r} from store"
-+                        f" channel {snap.channel!r} in target environment."
++                        f" channel {channel!r} in target environment."
 +                    ),
 +                    details=error.details,
 +                ) from error

--- a/deps/craft-store.nix
+++ b/deps/craft-store.nix
@@ -4,8 +4,7 @@
 }:
 let
   pname = "craft-store";
-  # Version 2.4.0 but version was not tagged
-  version = "2.4.0";
+  version = "2.6.0";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
@@ -14,8 +13,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "canonical";
     repo = pname;
-    rev = "721955c98fc5d991ab1233826d67faeed6f8c65d";
-    sha256 = "sha256-wNI3BVfSGWKV1hrMZ7hGNGksdHjCfv+vMLuoDh2f7M0=";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-VtKOe3IrvGcNWfp1/tg1cO94xtfkP7AbIHh0WTdlfbQ=";
   };
 
   postPatch = ''
@@ -28,6 +27,7 @@ pkgs.python3Packages.buildPythonPackage rec {
     macaroon-bakery
     overrides
     pydantic
+    pyxdg
     requests
     requests-toolbelt
     setuptools

--- a/deps/macaroon-bakery.nix
+++ b/deps/macaroon-bakery.nix
@@ -4,14 +4,14 @@
 }:
 let
   pname = "macaroonbakery";
-  version = "1.3.1";
+  version = "1.3.4";
 in
 pkgs.python3Packages.buildPythonPackage rec {
   inherit pname version;
 
   src = pkgs.python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-I/OEFTQaHQShVbTaxnMNOtXzm4bOB7G7E0vdpStIsFM=";
+    sha256 = "sha256-QcqZOiPk+O8v53I7XNSjDHWXNfHVAh6ZB3DIoODzOXA=";
   };
 
   propagatedBuildInputs = with pkgs.python3Packages; [

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "nmt": "nmt"
       },
       "locked": {
-        "lastModified": 1694984852,
-        "narHash": "sha256-A1x55uLb2LT9evsTWYc1U9+iki1AmE5ROxOuCKPf3JE=",
+        "lastModified": 1705252799,
+        "narHash": "sha256-HgSTREh7VoXjGgNDwKQUYcYo13rPkltW7IitHrTPA5c=",
         "owner": "Gerschtli",
         "repo": "nix-formatter-pack",
-        "rev": "23795a4daf29ce784b3edc13b9776c7b445c453b",
+        "rev": "2de39dedd79aab14c01b9e2934842051a160ffa5",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "lastModified": 1705242415,
+        "narHash": "sha256-a8DRYrNrzTudvO7XHUPNJD89Wbf1ZZT0VbwCsPnHWaE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "rev": "ea780f3de2d169f982564128804841500e85e373",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             spdx-lookup = final.callPackage ./deps/spdx-lookup.nix { };
             types-deprecated = final.callPackage ./deps/types-deprecated.nix { };
 
-            pydantic = python_prev.pydantic.overrideAttrs (oldAttrs: rec {
+            pydantic = python_prev.pydantic.overrideAttrs (_oldAttrs: rec {
               version = "1.10.13";
               pyproject = false;
 
@@ -69,7 +69,7 @@
 
             # versioningit 2.2.1 migrated to pydantic 2, which is incompatible with the
             # craft applications and libraries.
-            versioningit = python_prev.versioningit.overrideAttrs (oldAttrs: rec {
+            versioningit = python_prev.versioningit.overrideAttrs (_oldAttrs: rec {
               version = "2.2.0";
               src = prev.fetchFromGitHub {
                 owner = "jwodder";

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,18 @@
               preCheck = false;
               disabledTestPaths = false;
             });
+
+            # versioningit 2.2.1 migrated to pydantic 2, which is incompatible with the
+            # craft applications and libraries.
+            versioningit = python_prev.versioningit.overrideAttrs (oldAttrs: rec {
+              version = "2.2.0";
+              src = prev.fetchFromGitHub {
+                owner = "jwodder";
+                repo = "versioningit";
+                rev = "refs/tags/v${version}";
+                hash = "sha256-sM5n02ewzysYNctXLamZHxJa+61D+xnYennprXjoiYc=";
+              };
+            });
           })
         ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     {
       overlay = final: prev: {
         pythonPackagesOverlays = (prev.pythonPackagesOverlays or [ ]) ++ [
-          (_python-final: _python_prev: {
+          (_python-final: python_prev: {
             catkin-pkg = final.callPackage ./deps/catkin-pkg.nix { };
             craft-application = final.callPackage ./deps/craft-application.nix { };
             craft-archives = final.callPackage ./deps/craft-archives.nix { };
@@ -46,6 +46,26 @@
             spdx = final.callPackage ./deps/spdx.nix { };
             spdx-lookup = final.callPackage ./deps/spdx-lookup.nix { };
             types-deprecated = final.callPackage ./deps/types-deprecated.nix { };
+
+            pydantic = python_prev.pydantic.overrideAttrs (oldAttrs: rec {
+              version = "1.10.13";
+              pyproject = false;
+
+              src = prev.fetchFromGitHub {
+                owner = "pydantic";
+                repo = "pydantic";
+                rev = "refs/tags/v${version}";
+                hash = "sha256-ruDVcCLPVuwIkHOjYVuKOoP3hHHr7ItIY55Y6hUgR74=";
+              };
+
+              propagatedBuildInputs = with python_prev; [
+                setuptools
+                typing-extensions
+              ];
+
+              preCheck = false;
+              disabledTestPaths = false;
+            });
           })
         ];
 


### PR DESCRIPTION
This PR includes version bumps for applications:

- `rockcraft`: 1.0.1 -> 1.1.1
- `snapcraft` 7.5.3 -> 8.0.1

In addition, many of the core libraries have been updated.

During this time, Python packages have moved on sufficiently that it became necessary to overlay `pydantic` to ensure only version 1 is installed. This in turn meant overlaying `versioningit` to maintain compatibility.