### PR TITLE
apt: init at 2.7.6

### DIFF
--- a/apps/snapcraft/default.nix
+++ b/apps/snapcraft/default.nix
@@ -46,6 +46,7 @@ pkgs.python3Packages.buildPythonApplication {
 
   propagatedBuildInputs = with pkgs.python3Packages; [
     attrs
+    apt
     catkin-pkg
     click
     craft-archives

--- a/deps/apt.nix
+++ b/deps/apt.nix
@@ -1,0 +1,32 @@
+{ pkgs
+, lib
+, ...
+}:
+let
+  pname = "apt";
+  version = "2.7.6";
+in
+pkgs.python3Packages.buildPythonPackage rec {
+  inherit pname version;
+
+  src = pkgs.fetchgit {
+    url = "https://git.launchpad.net/python-apt";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-1jTe8ncMKV78+cfSZ6p6qdjxs0plZLB4VwVtPLtDlAc=";
+  };
+
+  # Ensure the version is set properly without trying to invoke
+  # dpkg-parsechangelog
+  env.DEBVER = "${version}";
+
+  buildInputs = with pkgs; [ apt.dev ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for APT";
+    homepage = "https://launchpad.net/python-apt";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}

--- a/deps/types-deprecated.nix
+++ b/deps/types-deprecated.nix
@@ -14,6 +14,8 @@ pkgs.python3Packages.buildPythonPackage rec {
     sha256 = "sha256-74cyet8+PEpMfY4G5Y9kdnENNGbs+1PEnvsICASnDvM=";
   };
 
+  doCheck = false;
+
   meta = {
     description = "Typing stubs for Deprecated.";
     homepage = "https://github.com/python/typeshed";

--- a/flake.nix
+++ b/flake.nix
@@ -44,29 +44,11 @@
             spdx-lookup = final.callPackage ./deps/spdx-lookup.nix { };
             types-deprecated = final.callPackage ./deps/types-deprecated.nix { };
 
-            pydantic = python_prev.pydantic.overrideAttrs (_oldAttrs: rec {
-              version = "1.10.13";
-              pyproject = false;
-
-              src = prev.fetchFromGitHub {
-                owner = "pydantic";
-                repo = "pydantic";
-                rev = "refs/tags/v${version}";
-                hash = "sha256-ruDVcCLPVuwIkHOjYVuKOoP3hHHr7ItIY55Y6hUgR74=";
-              };
-
-              propagatedBuildInputs = with python_prev; [
-                setuptools
-                typing-extensions
-              ];
-              doCheck = false;
-              preCheck = false;
-              disabledTestPaths = false;
-            });
+            pydantic = python_prev.pydantic_1;
 
             # versioningit 2.2.1 migrated to pydantic 2, which is incompatible with the
             # craft applications and libraries.
-            versioningit = python_prev.versioningit.overrideAttrs (_oldAttrs: rec {
+            versioningit = python_prev.versioningit.overridePythonAttrs (_oldAttrs: rec {
               version = "2.2.0";
               src = prev.fetchFromGitHub {
                 owner = "jwodder";

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
       overlay = final: prev: {
         pythonPackagesOverlays = (prev.pythonPackagesOverlays or [ ]) ++ [
           (_python-final: python_prev: {
+            apt = final.callPackage ./deps/apt.nix { };
             catkin-pkg = final.callPackage ./deps/catkin-pkg.nix { };
             craft-application = final.callPackage ./deps/craft-application.nix { };
             craft-archives = final.callPackage ./deps/craft-archives.nix { };

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
                 setuptools
                 typing-extensions
               ];
-
+              doCheck = false;
               preCheck = false;
               disabledTestPaths = false;
             });
@@ -74,6 +74,7 @@
                 rev = "refs/tags/v${version}";
                 hash = "sha256-sM5n02ewzysYNctXLamZHxJa+61D+xnYennprXjoiYc=";
               };
+              doCheck = false;
             });
           })
         ];


### PR DESCRIPTION
This PR adds the `python-apt` package and ensure's it's included in the build of snapcraft.

Fixes #51 (possibly!)